### PR TITLE
Modify the default URL of INSTALL_K3S_MIRROR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ set -e
 GITHUB_URL=https://github.com/rancher/k3s/releases
 STORAGE_URL=https://storage.googleapis.com/k3s-ci-builds
 DOWNLOADER=
-INSTALL_K3S_MIRROR_URL=${INSTALL_K3S_MIRROR_URL:-'https://mirror-k3s.rancher.cn'}
+INSTALL_K3S_MIRROR_URL=${INSTALL_K3S_MIRROR_URL:-'http://rancher-mirror.cnrancher.com'}
 
 # --- helper functions for logs ---
 info()
@@ -368,7 +368,7 @@ download_hash() {
         HASH_URL=${STORAGE_URL}/k3s${SUFFIX}-${INSTALL_K3S_COMMIT}.sha256sum
     elif [ "${INSTALL_K3S_MIRROR}" = cn ]; then
         VERSION_K3S=$( echo ${VERSION_K3S} | sed 's/+/-/g' )
-        HASH_URL=${INSTALL_K3S_MIRROR_URL}/download/${VERSION_K3S}/sha256sum-${ARCH}.txt
+        HASH_URL=${INSTALL_K3S_MIRROR_URL}/k3s/${VERSION_K3S}/sha256sum-${ARCH}.txt
     else
         HASH_URL=${GITHUB_URL}/download/${VERSION_K3S}/sha256sum-${ARCH}.txt
     fi
@@ -396,7 +396,7 @@ download_binary() {
         BIN_URL=${STORAGE_URL}/k3s${SUFFIX}-${INSTALL_K3S_COMMIT}
     elif [ "${INSTALL_K3S_MIRROR}" = cn ]; then
         VERSION_K3S=$( echo ${VERSION_K3S} | sed 's/+/-/g' )
-        BIN_URL=${INSTALL_K3S_MIRROR_URL}/download/${VERSION_K3S}/k3s${SUFFIX}
+        BIN_URL=${INSTALL_K3S_MIRROR_URL}/k3s/${VERSION_K3S}/k3s${SUFFIX}
     else
         BIN_URL=${GITHUB_URL}/download/${VERSION_K3S}/k3s${SUFFIX}
     fi


### PR DESCRIPTION
Execution log:
```
root@k3s1:~# curl -sfL http://rancher-mirror.oss-cn-beijing.aliyuncs.com/k3s/install.sh | INSTALL_K3S_MIRROR=cn sh -
[INFO]  Finding release for channel stable
[INFO]  Using v1.18.2+k3s1 as release
[INFO]  Downloading hash http://rancher-mirror.cnrancher.com/k3s/v1.18.2-k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary http://rancher-mirror.cnrancher.com/k3s/v1.18.2-k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Skipping /usr/local/bin/crictl symlink to k3s, already exists
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
```